### PR TITLE
feat: removed fontawesome kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,6 @@ To make *Angular* know about the Stoplight elements and their styling, you shoul
 }
 ```
 
-In addition, **Stoplight Elements needs Font Awesome 5** set up to display its icons.
-
-If you have not already, please either use a *kit* or refer to the [official documentation](https://fontawesome.com/how-to-use/on-the-web/setup/using-package-managers) on installing the CSS & WebFonts via NPM.
-
-> **NOTE:** Having the `@fortawesome/angular-fontawesome` package installed is **not sufficient**.
-> *Elements*'s custom elements are *framework-agnostic* and do not have access to the *Angular* components. They expect the global Font Awesome CSS to be included on the page.
-
 ### Step 3 - CUSTOM_ELEMENTS_SCHEMA
 
 In order to use custom elements in an *Angular* application, you have to add something called the *CUSTOM_ELEMENTS_SCHEMA*.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "~10.0.11",
     "@angular/platform-browser-dynamic": "~10.0.11",
     "@angular/router": "~10.0.11",
-    "@stoplight/elements-web-components": "beta",
+    "@stoplight/elements-web-components": "6.0.0-beta.163",
     "rxjs": "~6.6.2",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,6 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-
-    <script src="https://kit.fontawesome.com/353fd702c1.js" crossorigin="anonymous"></script>
   </head>
 
   <body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,10 +1119,10 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@stoplight/elements-web-components@beta":
-  version "6.0.0-beta.145"
-  resolved "https://registry.yarnpkg.com/@stoplight/elements-web-components/-/elements-web-components-6.0.0-beta.145.tgz#07956a8ecb17b14eb37f40355badf1da1b5e76c3"
-  integrity sha512-hK3I7RfVebU2uIV8FlGD8w3wzGtlQPE/KAz5efFEgopt1Y4rDo3GTu9Tm7oZP61wN0+9GTWGVuYHPfAyjhM33A==
+"@stoplight/elements-web-components@6.0.0-beta.163":
+  version "6.0.0-beta.163"
+  resolved "https://registry.yarnpkg.com/@stoplight/elements-web-components/-/elements-web-components-6.0.0-beta.163.tgz#4eea88cfec7d64506141f43acd944ec956d10276"
+  integrity sha512-AJBqy04EsnOJ51CN5SHW0SBKaFO62XC1qrEW/r+UKmVculMf/R2D+2Outf3KYAlWiNEN9ssWzcUBFPBfaQABmQ==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
bumped elements to 6.0.0-beta.163
updated README.md

Since we don't rely on Font Awesome Kit anymore. Part of https://github.com/stoplightio/elements/issues/525