### PR TITLE
chore: only bump dependency versions once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
+      interval: "monthly"
+    versioning-strategy: "increase-if-necessary"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
       interval: "daily"
+    allow:
+      - dependency-name: "@stoplight/elements-web-components"


### PR DESCRIPTION
Dep update PRs are annoying. On the other hand in order to keep this repo a reasonable example for angular users, we need to keep up with angular (and other pkg) versions. I picked a monthly bump as a compromise, let me know if you agree.

`elements-web-components` on the other hand should be updated ASAP, that is handled separately.