### PR TITLE
fix: workaround dependabot limitation by using two of them

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          dependency_name: "@stoplight/elements-web-components"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,3 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: "increase-if-necessary"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@stoplight/elements-web-components"


### PR DESCRIPTION
Alright, so dependabot keeps complaining about my last PR #18 because it cannot handle having different schedules for different packages.

See the problem here:
https://github.com/dependabot/dependabot-core/issues/1865

Maybe using Github's dependabot and the old one simultaneously does the trick. Let's see. I'm not sure this will work, but why not give it a try?