### PR TITLE
test(ci): run e2e tests on PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,3 +18,5 @@ jobs:
         run: yarn lint
       - name: Run production build
         run: yarn build
+      - name: Run e2e tests
+        run: yarn e2e:run


### PR DESCRIPTION
Adds running e2e tests to the CI check that runs on PRs. Makes merging dep updates, etc safer and quicker.